### PR TITLE
Embed api example queries as iframes

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -1,0 +1,52 @@
+# Example Queries
+
+We provided some example queries for you to try in the [API Sandbox](https://studio.apollographql.com/sandbox?endpoint=https%3A%2F%2Fapi.forta.network%2Fgraphql):
+
+* [Recent alerts emitted by a specific agent](#recent-alerts-emitted-by-a-specific-agent)
+* [Today's alerts associated with certain addressees](#todays-alerts-associated-with-certain-addressees)
+* [Past alerts by block number or date range](#past-alerts-by-block-number-or-date-range)
+* [A list of blockchain projects](#a-list-of-blockchain-projects)
+* [Details of a blockchain project](#details-of-a-blockchain-project)
+
+You can find all examples at [forta-protocol.github.io/forta-api](https://forta-protocol.github.io/forta-api/).
+
+## Recent alerts emitted by a specific agent
+
+You can also view [this example query on github](https://forta-protocol.github.io/forta-api/example_queries/recent_alerts.html).
+<iframe
+  src="https://forta-protocol.github.io/forta-api/example_queries/recent_alerts.html"
+  style="width:100%; height:500px;" frameborder="0"
+></iframe>
+
+## Today's alerts associated with certain addressees
+
+You can also view [this example query on github](https://forta-protocol.github.io/forta-api/example_queries/todays_alerts.html).
+<iframe
+  src="https://forta-protocol.github.io/forta-api/example_queries/todays_alerts.html"
+  style="width:100%; height:500px;" frameborder="0"
+></iframe>
+
+## Past alerts by block number or date range
+
+You can also view [this example query on github](https://forta-protocol.github.io/forta-api/example_queries/past_alerts.html).
+<iframe
+  src="https://forta-protocol.github.io/forta-api/example_queries/past_alerts.html"
+  style="width:100%; height:500px;" frameborder="0"
+></iframe>
+
+## A list of blockchain projects
+
+You can also view [this example query on github](https://forta-protocol.github.io/forta-api/example_queries/blockchain_projects_list.html).
+<iframe
+  src="https://forta-protocol.github.io/forta-api/example_queries/blockchain_projects_list.html"
+  style="width:100%; height:500px;" frameborder="0"
+></iframe>
+
+## Details of a blockchain project
+
+You can also view [this example query on github](https://forta-protocol.github.io/forta-api/example_queries/blockchain_project.html).
+<iframe
+  src="https://forta-protocol.github.io/forta-api/example_queries/blockchain_project.html"
+  style="width:100%; height:500px;" frameborder="0"
+></iframe>
+

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,4 @@
-# Forta API
+# API Access & Schema
 
 !!! important "Beta Mode"
     (February 2022) The API is in beta mode. If you see any bugs or issues, please let us know at [github:forta-protocol/forta-api](https://github.com/forta-protocol/forta-api/issues/new/choose).
@@ -22,11 +22,6 @@ Please visit the [API Sandbox](https://studio.apollographql.com/sandbox?endpoint
 <p align="left">
     <img alt="Forta API Schema" src="../api-schema.png" width="700">
 </p>
-
-## Any example queries I can try?
-
-We provided some example queries for you to try in the [API Sandbox](https://studio.apollographql.com/sandbox?endpoint=https%3A%2F%2Fapi.forta.network%2Fgraphql). You can find the examples in the [forta-api github repository](https://github.com/forta-protocol/forta-api#explore-example-queries).
-
 
 ## How can I contribute?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,9 @@ nav:
       - forta.config.json: config.md
   - Javascript/Typescript SDK: sdk.md
   - Python SDK: python.md
-  - Forta API: api.md
+  - Forta API: 
+      - API Access & Schema: api.md
+      - Example Queries: api-examples.md
   - Best practices: best-practices.md
   - Agent patterns:
       - Hiding sensitive data: sensitive-data.md


### PR DESCRIPTION
## Changes
Some changes to improve API docs/examples discovery. 

* Created separate pages for api access/schema and example queries
* Embedded example queries as iframes 

## Screenshots
<img width="257" alt="Screen Shot 2022-02-22 at 10 14 37 AM" src="https://user-images.githubusercontent.com/3497137/155175772-317c3168-37e1-46a9-9b40-8a7228bea0b5.png">

<img width="810" alt="Screen Shot 2022-02-22 at 11 27 02 AM" src="https://user-images.githubusercontent.com/3497137/155175748-c56f2a13-1eb4-4f26-842e-f1c7403ed90c.png">

